### PR TITLE
Added Docker Hub location to `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ This contains the definition for an Docker image for running tox to test python.
 Tox is a application to run python tests against multiple versions of python in
 virtual environments.
 
+Docker Hub
+==========
+
+The Docker instance is located
+[here](https://hub.docker.com/r/cscutcher/tox-pyenv-runner/) on
+[Docker hub](https://hub.docker.com).
+
 Running
 =======
 


### PR DESCRIPTION
Noticed that there was no link to the hub.docker.com page where this code has been deployed as an instance. Added it for you.
